### PR TITLE
Extend aikido timeout, don't fail on timeouts

### DIFF
--- a/aikido-validation.yaml
+++ b/aikido-validation.yaml
@@ -18,11 +18,11 @@ jobs:
         uses: actions/checkout@v2
       - name: Detect new vulnerabilities
         uses: AikidoSec/github-actions-workflow@main
-        continue-on-error: true
         with:
             secret-key: ${{ secrets.AIKIDO_SECRET_KEY }}
-            fail-on-timeout: true
+            fail-on-timeout: false
             fail-on-dependency-scan: true
             fail-on-sast-scan: true
             fail-on-iac-scan: true
             minimum-severity: 'CRITICAL'
+            timeout-seconds: 300


### PR DESCRIPTION
Jira Ticket Number: N/A

## What does this PR accomplish?
Currently the Aikido workflow fails on timeouts. This means we can't merge PRs when Aikido is down. While this is undoubtedly the most secure option, the impact on productivity is pretty high even during a short outage.

This PR increases the timeout (to avoid any normal edge cases) and disables failure on timeout. In a potential future Aikido outage, the check will still pass after 5 minutes rather than failing outright

## How did you test it?

N/A 

## How will you know that this is working after deployment?

N/A