### PR TITLE
Set aikido to comment on scan status

### DIFF
--- a/aikido-validation.yaml
+++ b/aikido-validation.yaml
@@ -26,3 +26,5 @@ jobs:
             fail-on-iac-scan: true
             minimum-severity: 'CRITICAL'
             timeout-seconds: 300
+            post-scan-status-comment: true
+            github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Jira Ticket Number: N/A

## What does this PR accomplish?

Aikido now supports commenting the scan status, this will enable it.

## How did you test it?

Haven't, this should just be a config option

## How will you know that this is working after deployment?

Aikido scans should start posting the scan status as a comment
